### PR TITLE
Inotify is very resource intensive

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,7 +61,11 @@ func mount(cmd *Cmd, target string) error {
 		return err
 	}
 	fmt.Println("mount starts")
-	fs.Wait()
+	if err := fs.Wait(); err != nil {
+		fmt.Fprintf(os.Stderr, "exit with error: %s", err)
+		os.Exit(1)
+	}
+
 	return nil
 }
 

--- a/g8ufs.go
+++ b/g8ufs.go
@@ -141,21 +141,13 @@ func (fs *G8ufs) Wait() error {
 	defer func() {
 		fs.umountFuse()
 	}()
-	//Wait for filesystem to be unmounted.
-	fd, err := syscall.InotifyInit()
-	if err != nil {
-		return err
-	}
 
-	defer syscall.Close(fd)
-
-	if _, err := syscall.InotifyAddWatch(fd, fs.target, syscall.IN_UNMOUNT); err != nil {
-		return err
-	}
-
-	buff := make([]byte, syscall.SizeofInotifyEvent)
-	if _, err := syscall.Read(fd, buff); err != nil {
-		return err
+	for {
+		cmd := exec.Command("mountpoint", "-q", fs.target)
+		if err := cmd.Run(); err != nil {
+			return nil
+		}
+		<-time.After(1 * time.Second)
 	}
 
 	return nil


### PR DESCRIPTION
To avoid changing the limits of the system, may be it's just
lighter to just check if the mount point still valid every second